### PR TITLE
Remove workaround note

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,7 @@ This is the actual process of generating appstream metadata from our repository,
     - Download new metadata to your local clone of the repo,
     - Commit the changes,
     - Add a new tag to the repository,
-    - _and push the changes to github._ - Work in progress  
-      Due to a [bug](https://github.com/getsolus/solus-appstream-data/issues/6), you will need to push the tags yourself with  
-      `git push --tags`
+    - and push the changes to github.
 > [!NOTE]
 > This would be a good time to take a break and do something else. Just make sure your computer doesn't go to sleep. It takes a while (about 30 minutes).
 5. Go to your clone of the packages monorepo and update the `appstream-data` package to use the newly-tagged version of this repository.  


### PR DESCRIPTION
Now that the playbook pushes tags correctly (9e052af), we can close #6 and remove the related workaround from README.md. 

## Test Plan:
- `git pull` your clone of this repository, *staying on the* `master` *branch* - ***do not check out this PR***.
- Run the full appstream generation process and see that it completes successfully, and that a new tag is created and pushed to this repo with no manual intervention.