### PR TITLE
Ignore `-devel` packages when symlinking packages to parse using appstream builder

### DIFF
--- a/create_symlinks.py
+++ b/create_symlinks.py
@@ -56,7 +56,8 @@ def parse_package_filename(package_filename: str) -> dict:
     output = {
         'name': package_split[0],
         'release': package_split[2],
-        'dbginfo': 'dbginfo' in package_filename
+        'dbginfo': 'dbginfo' in package_filename,
+        'devel': 'devel' in package_filename,
     }
     return output
 
@@ -65,6 +66,7 @@ def check_file(path: pathlib.Path, eopkg_packages: dict) -> bool:
     eopkg_info = parse_package_filename(path.name)
     if (eopkg_info['name'] in eopkg_packages.keys() and eopkg_info['release'] == eopkg_packages[eopkg_info['name']])\
         and not eopkg_info['dbginfo']\
+        and not eopkg_info['devel']\
         :
         return True
     else:

--- a/create_symlinks.py
+++ b/create_symlinks.py
@@ -56,8 +56,8 @@ def parse_package_filename(package_filename: str) -> dict:
     output = {
         'name': package_split[0],
         'release': package_split[2],
-        'dbginfo': 'dbginfo' in package_filename,
-        'devel': 'devel' in package_filename,
+        'dbginfo': package_split[0].endswith('-dbginfo'),
+        'devel':  package_split[0].endswith('-devel'),
     }
     return output
 


### PR DESCRIPTION
Does what it says on the tin. `-devel` packages never need to be listed in software centers, so we don't need to spend time parsing them with appstream-builder. 

As of the date of the PR, this change takes us from 7819 symlinked packages to parse all the way down to 5758. I call that a win!

This PR is currently deployed on teaparty, and was used to create tag v68. I can roll it back before final appstream generation for this week if anyone finds an issue with it.